### PR TITLE
Add basic Flask template rendering API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+instance/
+.env
+
+# Templates generated
+templates/*.j2

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn app:app

--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
 # DM_TemplateEditor
+
+A simple Flask service for generating creative assets based on Jinja2 templates.
+Templates and records are provided via HTTP API calls. The rendered output can
+be batched and optionally sent to an external system.
+
+## Features
+- Upload and store templates containing Jinja2 variables
+- Render single records or batches of records against templates
+- Optional webhook to forward rendered content to external systems
+- Ready for deployment to Heroku using `gunicorn`
+
+## Requirements
+Python 3.10+
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Running Locally
+```bash
+python app.py
+```
+The server listens on port `5000` by default.
+
+## API
+### `POST /template`
+Upload a template.
+```json
+{
+  "template_id": "welcome",
+  "content": "Hello {{ name }}!"
+}
+```
+
+### `POST /render`
+Render a single record.
+```json
+{
+  "template_id": "welcome",
+  "record": {"name": "Alice"},
+  "external_url": "https://example.com/webhook" // optional
+}
+```
+
+### `POST /batch`
+Render multiple records.
+```json
+{
+  "template_id": "welcome",
+  "records": [{"name": "Alice"}, {"name": "Bob"}],
+  "external_url": "https://example.com/webhook" // optional
+}
+```
+
+Each rendered result is also POSTed to `external_url` when provided.
+
+## Deploying to Heroku
+Create an app and push this repository. Heroku uses `Procfile` to start the
+application with `gunicorn`.
+
+```bash
+heroku create my-app
+heroku git:remote -a my-app
+heroku buildpacks:set heroku/python
+git push heroku main
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,87 @@
+import os
+from flask import Flask, request, jsonify
+from jinja2 import Template
+import requests
+
+app = Flask(__name__)
+
+TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), 'templates')
+os.makedirs(TEMPLATE_DIR, exist_ok=True)
+
+
+def save_template(template_id: str, content: str) -> str:
+    """Save a template file to disk and return its path."""
+    path = os.path.join(TEMPLATE_DIR, f"{template_id}.j2")
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+    return path
+
+
+def load_template(template_id: str) -> Template:
+    """Load a template by id."""
+    path = os.path.join(TEMPLATE_DIR, f"{template_id}.j2")
+    with open(path, encoding='utf-8') as f:
+        return Template(f.read())
+
+
+@app.route('/template', methods=['POST'])
+def upload_template():
+    """Upload a template with a template_id and content."""
+    data = request.get_json(force=True)
+    template_id = data['template_id']
+    content = data['content']
+    save_template(template_id, content)
+    return jsonify({'status': 'saved'}), 201
+
+
+def _render(template: Template, record: dict) -> str:
+    return template.render(record)
+
+
+def send_to_external(content: str, external_url: str) -> None:
+    """Send generated output to an external system via POST."""
+    try:
+        response = requests.post(external_url, json={'content': content}, timeout=10)
+        response.raise_for_status()
+    except Exception as exc:
+        app.logger.error('Failed to send to external system: %s', exc)
+
+
+@app.route('/render', methods=['POST'])
+def render_record():
+    """Render a single record against a template."""
+    data = request.get_json(force=True)
+    template_id = data['template_id']
+    record = data['record']
+    external_url = data.get('external_url')
+
+    template = load_template(template_id)
+    rendered = _render(template, record)
+
+    if external_url:
+        send_to_external(rendered, external_url)
+
+    return jsonify({'result': rendered})
+
+
+@app.route('/batch', methods=['POST'])
+def render_batch():
+    """Render multiple records against a template."""
+    data = request.get_json(force=True)
+    template_id = data['template_id']
+    records = data['records']
+    external_url = data.get('external_url')
+
+    template = load_template(template_id)
+    results = []
+    for record in records:
+        rendered = _render(template, record)
+        results.append(rendered)
+        if external_url:
+            send_to_external(rendered, external_url)
+
+    return jsonify({'results': results})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.2
+Jinja2==3.1.2
+requests==2.31.0
+gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- add Flask service to store templates and render records with Jinja2
- support batching and optional external webhook forwarding
- add requirements and Procfile for Heroku deployment

## Testing
- `python -m py_compile app.py`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"template_id":"welcome","content":"Hello {{ name }}"}' http://localhost:5000/template`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"template_id":"welcome","record":{"name":"Alice"}}' http://localhost:5000/render`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"template_id":"welcome","records":[{"name":"Alice"},{"name":"Bob"}]}' http://localhost:5000/batch`


------
https://chatgpt.com/codex/tasks/task_e_68a648820de4832dbf05e5e96a766272